### PR TITLE
Update to new Poetry Install Script

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -23,7 +23,7 @@ install_poetry() {
   fi
 
   curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py |
-    POETRY_HOME=$install_path python - --version "$version"
+    POETRY_HOME=$install_path python3 - --version "$version"
 }
 
 install_poetry "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/install
+++ b/bin/install
@@ -22,8 +22,8 @@ install_poetry() {
     fail "asdf-poetry supports release installs only"
   fi
 
-  curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py |
-    POETRY_HOME=$install_path python - --version "$version" --no-modify-path
+  curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py |
+    POETRY_HOME=$install_path python - --version "$version"
 }
 
 install_poetry "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/install
+++ b/bin/install
@@ -18,6 +18,11 @@ install_poetry() {
   local version=$2
   local install_path=$3
 
+  # Ensure the installer will work even if the user has the
+  # PIP_REQUIRE_VIRTUALENV variable set. Can be removed after this issue is
+  # resolved: https://github.com/python-poetry/poetry/issues/4089
+  unset PIP_REQUIRE_VIRTUALENV
+
   if [ "$install_type" != "version" ]; then
     fail "asdf-poetry supports release installs only"
   fi


### PR DESCRIPTION
Fixes #8.

Update the plugin to use the new poetry install script (https://python-poetry.org/blog/announcing-poetry-1.2.0a1/#deprecation-of-the-get-poetrypy-script). The new script is python3 only and no longer attempts to modify `$PATH`.

I've also unset the `PIP_REQUIRE_VIRTUALENV` variable during poetry install. The environmental variable shouldn't need to be unset, that is a bug, see https://github.com/python-poetry/poetry/issues/4089 for more details.