### PR TITLE
conditionally install with old installer

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install shfmt
-        run: brew upgrade && brew install shfmt
+        run: brew install shfmt
 
       - name: Run shfmt
         run: make fmt-check

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install shfmt
-        run: brew install shfmt
+        run: brew update && brew install shfmt
 
       - name: Run shfmt
         run: make fmt-check

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install shfmt
-        run: brew install shfmt
+        run: brew upgrade && brew install shfmt
 
       - name: Run shfmt
         run: make fmt-check

--- a/bin/install
+++ b/bin/install
@@ -13,8 +13,7 @@ cleanup() {
   echo "$(caller): ${BASH_COMMAND}"
 }
 
-semver_ge()
-{
+semver_ge() {
   printf '%s\n%s\n' "$2" "$1" | sort --check=quiet --version-sort
 }
 

--- a/bin/install
+++ b/bin/install
@@ -13,6 +13,11 @@ cleanup() {
   echo "$(caller): ${BASH_COMMAND}"
 }
 
+semver_ge()
+{
+  printf '%s\n%s\n' "$2" "$1" | sort --check=quiet --version-sort
+}
+
 install_poetry() {
   local install_type=$1
   local version=$2
@@ -27,8 +32,15 @@ install_poetry() {
     fail "asdf-poetry supports release installs only"
   fi
 
-  curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py |
-    POETRY_HOME=$install_path python3 - --version "$version"
+  semver_ge $ASDF_INSTALL_VERSION 1.2.0 && vercomp="ge" || vercomp="lt"
+
+  install_url="https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py"
+
+  if [ $vercomp == "ge" ]; then
+    install_url="https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py"
+  fi
+
+  curl -sSL $install | POETRY_HOME=$install_path python3 - --version "$version"
 }
 
 install_poetry "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/install
+++ b/bin/install
@@ -32,7 +32,7 @@ install_poetry() {
     fail "asdf-poetry supports release installs only"
   fi
 
-  semver_ge $ASDF_INSTALL_VERSION 1.2.0 && vercomp="ge" || vercomp="lt"
+  semver_ge "$ASDF_INSTALL_VERSION" 1.2.0 && vercomp="ge" || vercomp="lt"
 
   install_url="https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py"
 
@@ -40,7 +40,7 @@ install_poetry() {
     install_url="https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py"
   fi
 
-  curl -sSL $install | POETRY_HOME=$install_path python3 - --version "$version"
+  curl -sSL "$install_url" | POETRY_HOME=$install_path python3 - --version "$version"
 }
 
 install_poetry "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/test/install.bats
+++ b/test/install.bats
@@ -8,12 +8,12 @@
 
 @test "install works on version before 1.2" {
   run asdf install poetry 1.1.7
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 0 ]
   echo "$output" | grep "This installer is deprecated"
 }
 
 @test "install works on version after 1.2" {
   run asdf install poetry 1.2.0a1
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 0 ]
   echo "$output" | grep -v "This installer is deprecated"
 }

--- a/test/install.bats
+++ b/test/install.bats
@@ -5,3 +5,15 @@
   [ "$status" -eq 1 ]
   echo "$output" | grep "supports release installs only"
 }
+
+@test "install works on version before 1.2" {
+  run asdf install poetry 1.1.7
+  [ "$status" -eq 1 ]
+  echo "$output" | grep "This installer is deprecated"
+}
+
+@test "install works on version after 1.2" {
+  run asdf install poetry 1.2.0a1
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -v "This installer is deprecated"
+}


### PR DESCRIPTION
Since the new installer breaks the expected behavior with asdf, we use the old installer (until it's deleted) for versions of poetry prior to 1.2.0. For versions after 1.2.0 we use the new installer, since the old installer won't work with newer versions.

Workaround for https://github.com/asdf-community/asdf-poetry/issues/10 on versions prior to 1.2, due to https://github.com/python-poetry/poetry/issues/4199