### PR TITLE
legacy arg to not modify PATH

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -34,14 +34,14 @@ install_poetry() {
   semver_ge "$ASDF_INSTALL_VERSION" 1.2.0 && vercomp="ge" || vercomp="lt"
 
   install_url="https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py"
-  args="--no-modify-path"
+  args=" --no-modify-path"
 
   if [ $vercomp == "ge" ]; then
     install_url="https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py"
     args=""
   fi
 
-  curl -sSL "$install_url" | POETRY_HOME=$install_path python3 - --version "$version" "$args"
+  curl -sSL "$install_url" | POETRY_HOME=$install_path python3 - --version "$version""$args"
 }
 
 install_poetry "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/install
+++ b/bin/install
@@ -33,15 +33,13 @@ install_poetry() {
 
   semver_ge "$ASDF_INSTALL_VERSION" 1.2.0 && vercomp="ge" || vercomp="lt"
 
-  install_url="https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py"
-  args=" --no-modify-path"
-
   if [ $vercomp == "ge" ]; then
     install_url="https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py"
-    args=""
+    curl -sSL "$install_url" | POETRY_HOME=$install_path python3 - --version "$version"
+  else
+    install_url="https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py"
+    curl -sSL "$install_url" | POETRY_HOME=$install_path python3 - --version "$version" --no-modify-path
   fi
-
-  curl -sSL "$install_url" | POETRY_HOME=$install_path python3 - --version "$version""$args"
 }
 
 install_poetry "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/install
+++ b/bin/install
@@ -34,12 +34,14 @@ install_poetry() {
   semver_ge "$ASDF_INSTALL_VERSION" 1.2.0 && vercomp="ge" || vercomp="lt"
 
   install_url="https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py"
+  args="--no-modify-path"
 
   if [ $vercomp == "ge" ]; then
     install_url="https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py"
+    args=""
   fi
 
-  curl -sSL "$install_url" | POETRY_HOME=$install_path python3 - --version "$version"
+  curl -sSL "$install_url" | POETRY_HOME=$install_path python3 - --version "$version" "$args"
 }
 
 install_poetry "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"


### PR DESCRIPTION
In #10, I forgot that on the old installer we need to specify explicitly not to modify the path on installation. This was originally fixed in #5 