### PR TITLE
`install-poetry.py`: Use for `1.1.9` and up

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -31,7 +31,7 @@ install_poetry() {
     fail "asdf-poetry supports release installs only"
   fi
 
-  semver_ge "$ASDF_INSTALL_VERSION" 1.1.7 && vercomp="ge" || vercomp="lt"
+  semver_ge "$ASDF_INSTALL_VERSION" 1.1.9 && vercomp="ge" || vercomp="lt"
 
   if [ $vercomp == "ge" ]; then
     install_url="https://install.python-poetry.org"

--- a/bin/install
+++ b/bin/install
@@ -31,7 +31,7 @@ install_poetry() {
     fail "asdf-poetry supports release installs only"
   fi
 
-  semver_ge "$ASDF_INSTALL_VERSION" 1.2.0 && vercomp="ge" || vercomp="lt"
+  semver_ge "$ASDF_INSTALL_VERSION" 1.1.7 && vercomp="ge" || vercomp="lt"
 
   if [ $vercomp == "ge" ]; then
     install_url="https://install.python-poetry.org"


### PR DESCRIPTION
Part 1 of 2 fix for #10 / https://github.com/python-poetry/poetry/issues/3345

Error:
`ModuleNotFoundError: No module named 'cleo'`, Versions: Python 3.10 and poetry 1.1.9 - 1.1.11 during `poetry` invocation
`'Link' object has no attribute 'is_absolute'` poetry 1.1.7 - 1.1.8 during `poetry install` of `pycparser==0.20.0`

See also:
- https://github.com/python-poetry/poetry/releases/tag/1.1.7
- https://github.com/asdf-community/asdf-poetry/issues/10#issuecomment-979310607
- https://github.com/python-poetry/poetry/issues/4409#issuecomment-922277122