### PR TITLE
`install-poetry.py`: Use new official install location

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -34,7 +34,7 @@ install_poetry() {
   semver_ge "$ASDF_INSTALL_VERSION" 1.2.0 && vercomp="ge" || vercomp="lt"
 
   if [ $vercomp == "ge" ]; then
-    install_url="https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py"
+    install_url="https://install.python-poetry.org"
     curl -sSL "$install_url" | POETRY_HOME=$install_path python3 - --version "$version"
   else
     install_url="https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py"


### PR DESCRIPTION
This operates independently of poetry releases so it can pull
bugfixes merged outside of poetry's own release cadence.

Error:
`ModuleNotFoundError: No module named 'cleo'`

Versions: Python 3.10 and poetry 1.1.7 - 1.1.11

See also:
- https://github.com/python-poetry/install.python-poetry.org
- https://github.com/python-poetry/poetry/issues/3345#issuecomment-974542746

In conjunction with #14 this gets python 3.10 working with poetry
1.1.11 where ModuleNotFoundError: No module named 'cleo' was raised.