### PR TITLE
`ASDF_POETRY_INSTALL_URL`: Optionally override installer URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,22 @@ asdf plugin-add poetry https://github.com/asdf-community/asdf-poetry.git
 Check [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to
 install & manage versions.
 
+### Overriding installer
+
+`ASDF_POETRY_INSTALL_URL` is an optional variable you can specific to point to
+the hosted installer of your choosing, e.g. `get-poetry.py` or the new `install-poetry.py`
+(compatible with [1.1.7+](https://github.com/python-poetry/poetry/releases/tag/1.1.7) and 
+[default in 1.2](https://python-poetry.org/blog/announcing-poetry-1.2.0a1/#deprecation-of-the-get-poetrypy-script)).
+
+For example, to force `install-poetry.py` on 1.1.9:
+
+```
+ASDF_POETRY_INSTALL_URL=https://install.python-poetry.org asdf install poetry 1.1.9
+```
+
+Doing so is not recommended and may result in poetry installations which
+disregard the `asdf-python` plugin. See [issue #10](https://github.com/asdf-community/asdf-poetry/issues/10).
+
 ## License
 
 Licensed under the

--- a/bin/install
+++ b/bin/install
@@ -21,6 +21,7 @@ install_poetry() {
   local install_type=$1
   local version=$2
   local install_path=$3
+  local flags=
 
   # Ensure the installer will work even if the user has the
   # PIP_REQUIRE_VIRTUALENV variable set. Can be removed after this issue is
@@ -33,13 +34,19 @@ install_poetry() {
 
   semver_ge "$ASDF_INSTALL_VERSION" 1.2.0 && vercomp="ge" || vercomp="lt"
 
-  if [ $vercomp == "ge" ]; then
+  if [[ -n ${ASDF_POETRY_INSTALL_URL:-} ]]; then
+    install_url=$ASDF_POETRY_INSTALL_URL
+  elif [ $vercomp == "ge" ]; then
     install_url="https://install.python-poetry.org"
-    curl -sSL "$install_url" | POETRY_HOME=$install_path python3 - --version "$version"
   else
     install_url="https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py"
-    curl -sSL "$install_url" | POETRY_HOME=$install_path python3 - --version "$version" --no-modify-path
   fi
+
+  if [[ $install_url == *get-poetry* ]]; then
+    flags=--no-modify-path
+  fi
+
+  curl -sSL "$install_url" | POETRY_HOME=$install_path python3 - --version "$version" $flags
 }
 
 install_poetry "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"


### PR DESCRIPTION
Escape hatch for #14 issue (python `3.10` support for `>=1.1.9;<1.2`) while preserving the `get-poetry.py` default behavior. This only changes behavior when `ASDF_POETRY_INSTALL_URL` is passed in. Example:

If you haven't, uninstall: `asdf uninstall poetry 1.1.8;`

See also: [`asdf-python`](https://github.com/danhper/asdf-python/)'s [environmental variable](https://github.com/danhper/asdf-python/blob/225091e/bin/install#L19) e.g. `ASDF_PYTHON_PATCH_URL`, [`asdf-nodejs`](https://github.com/asdf-vm/asdf-nodejs/)'s [environmental variable](https://github.com/asdf-vm/asdf-nodejs/blob/1bc55cb/bin/install#L32) e.g. `NODEJS_CHECK_SIGNATURES`

## Default installer for <1.2 (get-poetry.py):

```
asdf install poetry 1.1.8
```

### Uninstall again:

```
asdf uninstall poetry 1.1.8;
```

## Notice the warning:

> This installer is deprecated. Poetry versions installed using this
> script will not be able to use 'self update' command to upgrade to
> 1.2.0a1 or later.

## Force install-poetry.py:

```
ASDF_POETRY_INSTALL_URL=https://install.python-poetry.org asdf install poetry 1.1.8
```