### PR TITLE
Use new Poetry installer whenever possible

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -32,11 +32,9 @@ install_poetry() {
     fail "asdf-poetry supports release installs only"
   fi
 
-  semver_ge "$ASDF_INSTALL_VERSION" 1.2.0 && vercomp="ge" || vercomp="lt"
-
   if [[ -n ${ASDF_POETRY_INSTALL_URL:-} ]]; then
     install_url=$ASDF_POETRY_INSTALL_URL
-  elif [ $vercomp == "ge" ]; then
+  elif semver_ge "$ASDF_INSTALL_VERSION" 1.1.7; then
     install_url="https://install.python-poetry.org"
   else
     install_url="https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py"
@@ -48,7 +46,7 @@ install_poetry() {
 
   curl -sSL "$install_url" | POETRY_HOME=$install_path python3 - --version "$version" $flags
 
-  if [ $vercomp == "ge" ]; then
+  if semver_ge "$ASDF_INSTALL_VERSION" 1.2.0; then
     # Ensure that poetry behaves as expected with asdf python (pyenv)
     echo Configuring poetry to behave properly with asdf ...
     echo Running: \"poetry config virtualenvs.prefer-active-python true\".

--- a/test/install.bats
+++ b/test/install.bats
@@ -6,14 +6,14 @@
   echo "$output" | grep "supports release installs only"
 }
 
-@test "install works on version before 1.2" {
-  run asdf install poetry 1.1.7
+@test "install works on version before 1.1.7" {
+  run asdf install poetry 1.1.6
   [ "$status" -eq 0 ]
   echo "$output" | grep "This installer is deprecated"
 }
 
-@test "install works on version after 1.2" {
-  run asdf install poetry 1.2.0
+@test "install works on version after 1.1.7" {
+  run asdf install poetry 1.1.7
   [ "$status" -eq 0 ]
   echo "$output" | grep -v "This installer is deprecated"
 }


### PR DESCRIPTION
Fixes #19.

Previously, the new installer hosted at https://install.python-poetry.org was only used for versions of Poetry that require it, namely 1.2+. [The official Poetry documentation](https://python-poetry.org/docs/1.1/#installation) recommends immediate migration from the old, deprecated, `get-poetry.py` installer to the new installer. Hence, use the new installer for all versions of Poetry that support it, namely 1.1.7+.

See [this official Poetry blog post announcing the release of 1.2.0](https://python-poetry.org/blog/announcing-poetry-1.2.0/#new-standalone-installer) for additional context.