### PR TITLE
Prefer active Python on Poetry 1.2+

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -47,6 +47,10 @@ install_poetry() {
   fi
 
   curl -sSL "$install_url" | POETRY_HOME=$install_path python3 - --version "$version" $flags
+
+  if [ $vercomp == "ge" ]; then
+    poetry config virtualenvs.prefer-active-python true
+  fi
 }
 
 install_poetry "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"


### PR DESCRIPTION
Fixes #10.

Set experimental `virtualenvs.prefer-active-python` config option, newly introduced in Poetry 1.2.0, to true globally on Poetry 1.2+. Instruct Poetry to use the active version of Python rather than the version of Python that was active at the time the virtualenv was created. Spare the end developer the hassle of running `poetry env use "$(asdf which python)"` or blowing away and recreating their virtualenv when swapping Python versions.