### PR TITLE
Feature/autocompletion

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -65,9 +65,15 @@ install_poetry() {
 
   if [ $config_vercomp == "ge" ]; then
     if echo "$SHELL" | grep -q "bash"; then
-      echo "Detected default shell bash"
-      echo "Setting up autocompletion for bash..."
-      "$install_path"/bin/poetry completions bash >~/.bash_completion
+      if [ ! -f "$HOME/.bash_completion" ]; then
+        echo "Detected default shell bash"
+        echo "Setting up autocompletion for bash..."
+        "$install_path"/bin/poetry completions bash >~/.bash_completion
+      elif grep -q '_poetry_' ~/.bash_completion; then
+        echo "Detected default shell bash"
+        echo "Setting up autocompletion for bash..."
+        "$install_path"/bin/poetry completions bash >~/.bash_completion
+      fi
     elif echo "$SHELL" | grep -q "zsh"; then
       if [ ! -d "$HOME/.zfunc/" ]; then
         mkdir -p ~/.zfunc
@@ -80,9 +86,11 @@ install_poetry() {
       grep -qxF 'fpath+=~/.zfunc' ~/.zshrc || echo "fpath+=~/.zfunc" >>~/.zshrc
       grep -qxF 'autoload -Uz compinit && compinit' ~/.zshrc || echo "autoload -Uz compinit && compinit" >>~/.zshrc
     elif echo "$SHELL" | grep -q "fish"; then
-      echo "Detected default shell fish"
-      echo "Setting up autocompletion for fish..."
-      "$install_path"/bin/poetry completions fish >~/.config/fish/completions/poetry.fish
+      if [ ! -f "$HOME/.config/fish/completions/poetry.fish" ]; then
+        echo "Detected default shell fish"
+        echo "Setting up autocompletion for fish..."
+        "$install_path"/bin/poetry completions fish >~/.config/fish/completions/poetry.fish
+      fi
     else
       echo "Warning: Could not detect BASH, ZSH or FISH."
       echo "Could not complete autocompletion setup"

--- a/bin/install
+++ b/bin/install
@@ -62,6 +62,34 @@ install_poetry() {
     echo Consider upgrading to a later version.
     echo https://github.com/asdf-community/asdf-poetry/issues/10
   fi
+
+  if [ $config_vercomp == "ge" ]; then
+    if echo "$SHELL" | grep -q "bash"; then
+      echo "Detected default shell bash"
+      echo "Setting up autocompletion for bash..."
+      "$install_path"/bin/poetry completions bash >~/.bash_completion
+    elif echo "$SHELL" | grep -q "zsh"; then
+      if [ ! -d "$HOME/.zfunc/" ]; then
+        mkdir -p ~/.zfunc
+      fi
+      if [ ! -f "$HOME/.zfunc/_poetry" ]; then
+        echo "Detected default shell zsh"
+        echo "Setting up autocompletion for zsh..."
+        "$install_path"/bin/poetry completions zsh >~/.zfunc/_poetry
+      fi
+      grep -qxF 'fpath+=~/.zfunc' ~/.zshrc || echo "fpath+=~/.zfunc" >>~/.zshrc
+      grep -qxF 'autoload -Uz compinit && compinit' ~/.zshrc || echo "autoload -Uz compinit && compinit" >>~/.zshrc
+    elif echo "$SHELL" | grep -q "fish"; then
+      echo "Detected default shell fish"
+      echo "Setting up autocompletion for fish..."
+      "$install_path"/bin/poetry completions fish >~/.config/fish/completions/poetry.fish
+    else
+      echo "Warning: Could not detect BASH, ZSH or FISH."
+      echo "Could not complete autocompletion setup"
+    fi
+  else
+    echo "Warning: Poetry versions prior to 1.2.0 will not have autocompletion"
+  fi
 }
 
 install_poetry "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"


### PR DESCRIPTION
Thought I'd give #27 a crack.

Based changes off the following documentation: https://python-poetry.org/docs/#enable-tab-completion-for-bash-fish-or-zsh

- Checks if version is greater than 1.2.0. If not, informs the user autocompletion won't be setup
- Checks the users default shell
- Runs through some validation to check if files/references already exist based off the default shell
- If files/references don't exist, run commands and update shell profiles
- If no shell matches are found an else statement informs the user it could not find a match

Full disclosure. I was able to fully test with zsh and worked great. I did try setting my default shell to bash/fish, but came across issues just creating a new terminal session so was unable to test the bash/fish side running `asdf install poetry 1.2.2`.

I'll try creating a container, installing asdf with bash/fish over the next few days and check the results. But wanted to create this PR as I'm sure the functionality is there and wanted this change to be open for discussion.