### PR TITLE
Add list-legacy-filenames file to allow for use of .poetry-version file.

### DIFF
--- a/bin/list-legacy-filenames
+++ b/bin/list-legacy-filenames
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo ".poetry-version"


### PR DESCRIPTION
By adding a list-legacy-filenames file to this plugin, projects that profile .[TOOL]-version files can use .poetry-version to control the version of poetry in use, rather than having to use .tool-versions.