### PR TITLE
fix(install): add support for poetry 2.0 configuration flag `virtualenvs.use-poetry-python`

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -26,9 +26,11 @@ install_poetry() {
   if [ "$install_type" == "version" ]; then
     semver_ge "$ASDF_INSTALL_VERSION" 1.1.7 && install_vercomp="ge" || install_vercomp="lt"
     semver_ge "$ASDF_INSTALL_VERSION" 1.2.0 && config_vercomp="ge" || config_vercomp="lt"
+    semver_ge "$ASDF_INSTALL_VERSION" 2.0.0 && venv_vercomp="ge" || venv_vercomp="lt"
   else
     install_vercomp="ge"
     config_vercomp="lt"
+    venv_vercomp="lt"
   fi
 
   if [[ -n ${ASDF_POETRY_INSTALL_URL-} ]]; then
@@ -55,9 +57,15 @@ install_poetry() {
   if [ "$config_vercomp" == "ge" ]; then
     # Ensure that poetry behaves as expected with asdf python (pyenv)
     echo Configuring poetry to behave properly with asdf ...
-    echo Running: \"poetry config virtualenvs.prefer-active-python true\".
-    echo ""
-    "$install_path"/bin/poetry config virtualenvs.prefer-active-python true
+    if [ "$venv_vercomp" == "ge" ]; then
+      echo Running: \"poetry config virtualenvs.use-poetry-python true\".
+      echo ""
+      "$install_path"/bin/poetry config virtualenvs.use-poetry-python true
+    else
+      echo Running: \"poetry config virtualenvs.prefer-active-python true\".
+      echo ""
+      "$install_path"/bin/poetry config virtualenvs.prefer-active-python true
+    fi
   else
     echo Warning: Poetry versions prior to 1.2.0 may not work properly with asdf.
     echo Consider upgrading to a later version.


### PR DESCRIPTION
This PR adds support for 2.0 changes of `virtualenvs.use-poetry-python` while leaving `virtualenvs.prefer-active-python` for older versions.

Fixes: https://github.com/asdf-community/asdf-poetry/issues/47