### PR TITLE
Update asdf commands with 0.16+ version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ manager
 ## Installation
 
 ```bash
+asdf plugin add poetry https://github.com/asdf-community/asdf-poetry.git
+```
+
+For pre-0.16.0 asdf versions:
+
+```bash
 asdf plugin-add poetry https://github.com/asdf-community/asdf-poetry.git
 ```
 


### PR DESCRIPTION
`asdf plugin-add` doesn't work with asdf 0.16+, so update README to include both versions.

Similar to change here:
- https://github.com/asdf-community/asdf-python/pull/205

Ref:
- https://asdf-vm.com/guide/upgrading-to-v0-16.html